### PR TITLE
V1 core0.5.34

### DIFF
--- a/contracts/test/TestERC20.sol
+++ b/contracts/test/TestERC20.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: GPL-v3
 pragma solidity 0.8.19;
 
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
@@ -9,7 +9,7 @@ contract TestERC20 is ERC20 {
 
     constructor(string memory name_, string memory symbol_) ERC20(name_, symbol_) {
         owner = msg.sender;
-        _mint(msg.sender, 100000 * 1e18);
+        _mint(msg.sender, 100000 * (10 ** decimals()));
     }
 
     function getSender() public virtual view returns(address) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gammaswap/v1-liquidator",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Smart contract for GammaSwap V1 liquidation bot",
   "homepage": "https://gammaswap.com",
   "main": "index.js",
@@ -61,8 +61,8 @@
     "typescript": ">=4.5.0"
   },
   "dependencies": {
-    "@gammaswap/v1-core": "^0.5.31",
-    "@gammaswap/v1-implementations": "^0.5.14",
-    "@gammaswap/v1-periphery": "0.5.11"
+    "@gammaswap/v1-core": "^0.5.34",
+    "@gammaswap/v1-implementations": "^0.5.15",
+    "@gammaswap/v1-periphery": "0.5.12"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -475,32 +475,32 @@
     "@ethersproject/properties" "^5.7.0"
     "@ethersproject/strings" "^5.7.0"
 
-"@gammaswap/v1-core@^0.5.31":
-  version "0.5.31"
-  resolved "https://npm.pkg.github.com/download/@gammaswap/v1-core/0.5.31/79f81813335484a75ff9f5fe9f9b1201e88fba3d#79f81813335484a75ff9f5fe9f9b1201e88fba3d"
-  integrity sha512-ZLRtsMmAQv/+2mYJUmg4enU18k2t7+QNeivdUX+82sZdkfilF/vGYN2YIskmKjlfaoiHedFOcbWG26x7YKYeUA==
+"@gammaswap/v1-core@^0.5.34":
+  version "0.5.34"
+  resolved "https://npm.pkg.github.com/download/@gammaswap/v1-core/0.5.34/61fb2dda51bd0c37a681ed2638355d4094c1ce69#61fb2dda51bd0c37a681ed2638355d4094c1ce69"
+  integrity sha512-63nNnxkm6ZCQwmwbHl5Qed8viYEsavZWnHKOYmc6cFqy8imn+K/O9pmLs1mIokMxey6J8Jvr5hRjdnfHoBOa6w==
   dependencies:
     "@openzeppelin/contracts" "^4.7.0"
 
-"@gammaswap/v1-implementations@^0.5.14":
-  version "0.5.14"
-  resolved "https://npm.pkg.github.com/download/@gammaswap/v1-implementations/0.5.14/751e48290457779663a6609da032cee5218e7155#751e48290457779663a6609da032cee5218e7155"
-  integrity sha512-TzirAT8tuZMCI4TzanQyfeF8+2/TgPVDTuw2NxVEqHqHUkj0k1WOyS0H6iCEUZo+vZRxFqnsw+o3Ka8MZB6r9w==
+"@gammaswap/v1-implementations@^0.5.15":
+  version "0.5.15"
+  resolved "https://npm.pkg.github.com/download/@gammaswap/v1-implementations/0.5.15/04afb28e07e8ea61fd72712896c9e4e90e3fb37b#04afb28e07e8ea61fd72712896c9e4e90e3fb37b"
+  integrity sha512-t5yj5EEh1hsyMTadkowGbOVt9qfWoPIrGighzMdQyN7GTAPTdh7G3S/4rxwav4P9R3Px3LL2dVR2+nAviznehw==
   dependencies:
     "@balancer-labs/v2-pool-utils" "^3.0.1"
     "@balancer-labs/v2-pool-weighted" "^2.0.1"
     "@balancer-labs/v2-solidity-utils" "^3.0.1"
     "@balancer-labs/v2-vault" "^3.0.1"
-    "@gammaswap/v1-core" "^0.5.31"
+    "@gammaswap/v1-core" "^0.5.34"
     "@openzeppelin/contracts" "^4.7.0"
     "@prb/math" "^3.1.0"
 
-"@gammaswap/v1-periphery@0.5.11":
-  version "0.5.11"
-  resolved "https://npm.pkg.github.com/download/@gammaswap/v1-periphery/0.5.11/dfc7d31210f35ce935ab3ad5fcc19541dceef09e#dfc7d31210f35ce935ab3ad5fcc19541dceef09e"
-  integrity sha512-N+WdEjyux966/a1teyNjgbZXhgrldnKsY6WglcqO/EuPr4msMswIyw2QVLnzn88A67yRmIbYAKgZdwI3n2bFXg==
+"@gammaswap/v1-periphery@0.5.12":
+  version "0.5.12"
+  resolved "https://npm.pkg.github.com/download/@gammaswap/v1-periphery/0.5.12/9c8ab005b82292dbf1e6cffd6ee521be3f597ca6#9c8ab005b82292dbf1e6cffd6ee521be3f597ca6"
+  integrity sha512-zKdEBMxI/Ibglkox+04Kzg6kKlR5ZgTl8Ue9jVKlenCKQbSPYlpyXvSqSjgqyBNVgRQf+P9RDTqJMh5SzIoqyw==
   dependencies:
-    "@gammaswap/v1-core" "^0.5.31"
+    "@gammaswap/v1-core" "^0.5.34"
     "@openzeppelin/contracts" "^4.7.0"
 
 "@jridgewell/resolve-uri@^3.0.3":


### PR DESCRIPTION
-update v1-core, v1-implementations, and v1-periphery to latest versions
-use decimals() in number expansion of TestERC20 contract
-change license of TestERC20 to GPLv3